### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-redis==2.10.5
+redis==2.10.6
 -e git+https://github.com/phovea/phovea_server.git@develop#egg=phovea_server


### PR DESCRIPTION
Make requirements equal to the one in the phovea_python docker image. This docker image is used for the phovea_server.
With PR https://github.com/phovea/phovea_python/pull/1 the redis requirement will be removed and must be reflected here.