### PR TITLE
Fix `SimpleCache` import by adding cachelib dependency

### DIFF
--- a/phovea_data_redis/assigner.py
+++ b/phovea_data_redis/assigner.py
@@ -24,7 +24,7 @@ class RedisIDAssigner(object):
     self._db = redis.Redis(host=c.hostname, port=c.port, db=c.db, charset='utf-8', decode_responses=True, **c.extras)
     wait_for_redis_ready(self._db)
 
-    from werkzeug.contrib.cache import SimpleCache
+    from cachelib import SimpleCache
     self._cache = SimpleCache(threshold=c.cache)
 
   @staticmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 redis~=2.10.6
+cachelib==0.1
 -e git+https://github.com/phovea/phovea_server.git@develop#egg=phovea_server


### PR DESCRIPTION
Fixes #29

### Summary

According to the [Werkzeug changelog v0.15.0](https://github.com/pallets/werkzeug/blob/dfde671ef969e27c7b14bd464688c009b34a7d2b/CHANGES.rst#version-0150) the `cache` has been extracted into a separate project, [cachelib](https://github.com/pallets/cachelib). The data structure and functionality should remain the same.

![grafik](https://user-images.githubusercontent.com/5851088/74023945-163ed400-49a1-11ea-9309-a47bbe3745d0.png)


